### PR TITLE
Fix/#44

### DIFF
--- a/src/main/kotlin/io/toasting/domain/post/application/PostService.kt
+++ b/src/main/kotlin/io/toasting/domain/post/application/PostService.kt
@@ -2,6 +2,7 @@ package io.toasting.domain.post.application
 
 import io.toasting.api.PageResponse
 import io.toasting.api.code.status.ErrorStatus
+import io.toasting.domain.member.entity.Member
 import io.toasting.domain.member.entity.MemberDetails
 import io.toasting.domain.member.exception.MemberExceptionHandler
 import io.toasting.domain.member.repository.MemberRepository
@@ -73,7 +74,7 @@ class PostService(
                 url = crawledPost.link,
                 postedAt = postedAt,
                 shortContent = shortContent,
-                content = text,
+                content = crawledPost.content,
                 title = crawledPost.title,
                 memberId = memberId
             )

--- a/src/main/kotlin/io/toasting/domain/post/application/PostService.kt
+++ b/src/main/kotlin/io/toasting/domain/post/application/PostService.kt
@@ -55,6 +55,7 @@ class PostService(
     fun linkBlog(memberDetails: MemberDetails, id: String, sourceType: String) {
         val memberId = memberDetails.username.toLong()
         var member = memberRepository.findById(memberId).orElseThrow{ MemberExceptionHandler.MemberNotFoundException(ErrorStatus.MEMBER_NOT_FOUND) }
+        validateAlreadyLinkedBlog(member, sourceType)
         member.registerBlog(sourceType, id)
         memberRepository.save(member)
 
@@ -79,6 +80,13 @@ class PostService(
             postList.add(post)
         }
         postRepository.saveAll(postList)
+    }
+
+    fun validateAlreadyLinkedBlog(member: Member, sourceType: String) {
+        if ((sourceType.equals("tistory") && !member.tistoryId.isNullOrBlank()) ||
+            (sourceType.equals("velog") && !member.velogId.isNullOrBlank())) {
+            throw PostExceptionHandler.AlreadyLinkedBlog(ErrorStatus.ALREADY_LINKED_BLOG)
+        }
     }
 
     fun getPostDetail(postId: Long): GetPostDetailOutput {

--- a/src/main/kotlin/io/toasting/domain/post/controller/PostController.kt
+++ b/src/main/kotlin/io/toasting/domain/post/controller/PostController.kt
@@ -25,7 +25,7 @@ internal class PostController(
             sort = arrayOf("postedAt"),
             direction = Sort.Direction.DESC,
         ) pageable: Pageable,
-        @RequestParam("keyword", required = false) keyword: String,
+        @RequestParam("keyword", required = false) keyword: String?,
     ): ApiResponse<PageResponse<SearchPostsResponse>> {
         val output = postService.searchPost(keyword, pageable)
         val response = output.content.map { SearchPostsResponse.from(it) }

--- a/src/main/kotlin/io/toasting/domain/post/exception/PostExceptionHandler.kt
+++ b/src/main/kotlin/io/toasting/domain/post/exception/PostExceptionHandler.kt
@@ -7,4 +7,8 @@ sealed class PostExceptionHandler {
     class PostNotFoundException(
         errorCode: BaseErrorCode
     ) : GeneralException(errorCode)
+
+    class AlreadyLinkedBlog(
+        errorCode: BaseErrorCode
+    ) : GeneralException(errorCode)
 }

--- a/src/main/kotlin/io/toasting/global/api/code/status/ErrorStatus.kt
+++ b/src/main/kotlin/io/toasting/global/api/code/status/ErrorStatus.kt
@@ -31,7 +31,9 @@ enum class ErrorStatus(
     PARTNER_NOT_FOUND(HttpStatus.BAD_REQUEST, "PARTNER_NOT_FOUND", "상대방을 찾을 수 없습니다."),
     CHAT_ROOM_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "CHAT_ROOM_ALREADY_EXISTS", "이미 채팅방이 존재합니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "게시글을 찾을 수 없습니다."),
-    SELF_FOLLOW_BANNED(HttpStatus.BAD_REQUEST, "SELF_FOLLOW_BANNED", "자신을 팔로우 할 수 없습니다.");
+    SELF_FOLLOW_BANNED(HttpStatus.BAD_REQUEST, "SELF_FOLLOW_BANNED", "자신을 팔로우 할 수 없습니다."),
+    ALREADY_LINKED_BLOG(HttpStatus.BAD_REQUEST, "ALREADY_LINKED_BLOG", "이미 블로그를 연동했습니다."),
+    ;
 
     override fun getReason() =
         ErrorReasonDTO(


### PR DESCRIPTION
### 관련 이슈
- https://github.com/team-aio/toasting-backend/issues/44

---

- query param nullable 타입에 ? 추가
- 블로그 연동 시, content에 html 태그 포함한 데이터 저장되도록 수정
- 블로그 이미 연동 했을 시, 예외 처리 추가